### PR TITLE
fix(shrine): use relative paths for correct module resolution.

### DIFF
--- a/shrine/app/index.html
+++ b/shrine/app/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html class="shrine" ng-strict-di>
   <meta charset="utf-8">
-  <base href="/"></base>
+  <base href="/">
   <title>Shrine - Adaptive UI</title>
   <meta name="description" content="Shrine - Adaptive UI Demo">
   <meta name="viewport" content="width=device-width">

--- a/shrine/app/src/model/featured/HeroStorage.js
+++ b/shrine/app/src/model/featured/HeroStorage.js
@@ -2,7 +2,7 @@
  * In-memory implementation of hero store.
  */
 
-import Hero from 'Hero';
+import Hero from './Hero';
 
 const STORE = [
   Hero.fromJson({

--- a/shrine/app/src/model/products/ItemStorage.js
+++ b/shrine/app/src/model/products/ItemStorage.js
@@ -2,7 +2,7 @@
  * In-memory implementation of item store.
  */
 
-import Item from 'Item';
+import Item from './Item';
 
 const STORE = [
   Item.fromJson({


### PR DESCRIPTION
Shrine doesn't load locally, because the module resolution can't find the the correct files.